### PR TITLE
Clear left for disqus

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -222,6 +222,10 @@ a:hover {
   border-top: 1px solid #ddd;
 }
 
+#disqus_thread {
+  clear: left;
+}
+
 @media (max-width: 650px) {
   #header {
     padding-top: 40px;


### PR DESCRIPTION
Since tags are inline blocks, so the disqus block will sit beside them, clear left to make sure that it will start from next line.
What do you think of this solution?
